### PR TITLE
Build p6spy before integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,15 @@ matrix:
       env: AS=jboss42x
 
 before_install:
+  - export JAVA_HOME_TEMP=$JAVA_HOME
+  - jdk_switcher use oraclejdk8
+  - git clone https://github.com/p6spy/p6spy.git
+  - pushd p6spy
+  - mvn clean install -DskipTests=true
+  - popd
+  - export JAVA_HOME=$JAVA_HOME_TEMP
+  - echo $JAVA_HOME
+  - java -version
   - export ORG_GRADLE_PROJECT_container=${AS}
 
 script: ./gradlew unitTest --info


### PR DESCRIPTION
The integration tests won't be dependent on a snapshot repository
but will rather install the latest master into the local maven repo